### PR TITLE
Apply `autopep8 --in-place --recursive .` command for Python file formatting

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -20,7 +20,8 @@ sys.path.append(root)
 # this is the Alembic Config object, which provides access to the values
 # within the .ini file in use.
 config = context.config
-database_url = os.getenv('DATABASE_URL') if os.getenv('DATABASE_URL') else 'sqlite:///./test.db'
+database_url = os.getenv('DATABASE_URL') if os.getenv(
+    'DATABASE_URL') else 'sqlite:///./test.db'
 config.set_main_option('sqlalchemy.url', database_url)
 
 # Interpret the config file for Python logging.

--- a/alembic/versions/27fe156a6d72_change_schema_to_unicode.py
+++ b/alembic/versions/27fe156a6d72_change_schema_to_unicode.py
@@ -17,8 +17,11 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column('interactions', sa.Column('client_message_unicode', sa.Unicode(65535)))
-    op.add_column('interactions', sa.Column('server_message_unicode', sa.Unicode(65535)))
+    op.add_column('interactions', sa.Column(
+        'client_message_unicode', sa.Unicode(65535)))
+    op.add_column('interactions', sa.Column(
+        'server_message_unicode', sa.Unicode(65535)))
+
 
 def downgrade() -> None:
     op.drop_column('interactions', 'client_message_unicode')

--- a/alembic/versions/3821f7adaca9_add_session_id.py
+++ b/alembic/versions/3821f7adaca9_add_session_id.py
@@ -17,7 +17,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column('interactions', sa.Column('session_id', sa.String(50), nullable=True))
+    op.add_column('interactions', sa.Column(
+        'session_id', sa.String(50), nullable=True))
 
 
 def downgrade() -> None:

--- a/alembic/versions/9ed6d1431c1d_add_platform_and_action_types.py
+++ b/alembic/versions/9ed6d1431c1d_add_platform_and_action_types.py
@@ -17,8 +17,10 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column('interactions', sa.Column('platform', sa.String(50), nullable=True))
-    op.add_column('interactions', sa.Column('action_type', sa.String(50), nullable=True))
+    op.add_column('interactions', sa.Column(
+        'platform', sa.String(50), nullable=True))
+    op.add_column('interactions', sa.Column(
+        'action_type', sa.String(50), nullable=True))
 
 
 def downgrade() -> None:

--- a/alembic/versions/eced1ae3918a_add_string_user_id.py
+++ b/alembic/versions/eced1ae3918a_add_string_user_id.py
@@ -17,7 +17,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column('interactions', sa.Column('user_id', sa.String(50), nullable=True))
+    op.add_column('interactions', sa.Column(
+        'user_id', sa.String(50), nullable=True))
 
     # Populate the new column with the old column's data
     op.execute("""

--- a/realtime_ai_character/database/chroma.py
+++ b/realtime_ai_character/database/chroma.py
@@ -9,7 +9,9 @@ logger = get_logger(__name__)
 
 embedding = OpenAIEmbeddings(openai_api_key=os.getenv("OPENAI_API_KEY"))
 if os.getenv('OPENAI_API_TYPE') == 'azure':
-    embedding = OpenAIEmbeddings(openai_api_key=os.getenv("OPENAI_API_KEY"), deployment=os.getenv("OPENAI_API_EMBEDDING_DEPLOYMENT_NAME", "text-embedding-ada-002"), chunk_size=1)
+    embedding = OpenAIEmbeddings(openai_api_key=os.getenv("OPENAI_API_KEY"), deployment=os.getenv(
+        "OPENAI_API_EMBEDDING_DEPLOYMENT_NAME", "text-embedding-ada-002"), chunk_size=1)
+
 
 def get_chroma():
     chroma = Chroma(

--- a/realtime_ai_character/llm/openai_llm.py
+++ b/realtime_ai_character/llm/openai_llm.py
@@ -15,11 +15,13 @@ from realtime_ai_character.utils import Character
 
 logger = get_logger(__name__)
 
+
 class OpenaiLlm(LLM):
     def __init__(self, model):
         if os.getenv('OPENAI_API_TYPE') == 'azure':
             self.chat_open_ai = AzureChatOpenAI(
-                deployment_name=os.getenv('OPENAI_API_MODEL_DEPLOYMENT_NAME', 'gpt-35-turbo'),
+                deployment_name=os.getenv(
+                    'OPENAI_API_MODEL_DEPLOYMENT_NAME', 'gpt-35-turbo'),
                 model=model,
                 temperature=0.5,
                 streaming=True

--- a/realtime_ai_character/models/interaction.py
+++ b/realtime_ai_character/models/interaction.py
@@ -7,11 +7,13 @@ class Interaction(Base):
     __tablename__ = "interactions"
 
     id = Column(Integer, primary_key=True, index=True, nullable=False)
-    client_id = Column(Integer) # deprecated, use user_id instead
+    client_id = Column(Integer)  # deprecated, use user_id instead
     user_id = Column(String(50))
     session_id = Column(String(50))
-    client_message = Column(String) # deprecated, use client_message_unicode instead
-    server_message = Column(String) # deprecated, use server_message_unicode instead
+    # deprecated, use client_message_unicode instead
+    client_message = Column(String)
+    # deprecated, use server_message_unicode instead
+    server_message = Column(String)
     client_message_unicode = Column(Unicode(65535))
     server_message_unicode = Column(Unicode(65535))
 

--- a/realtime_ai_character/websocket_routes.py
+++ b/realtime_ai_character/websocket_routes.py
@@ -120,8 +120,8 @@ async def handle_receive(
         tts_task = asyncio.create_task(text_to_speech.stream(
             text=GREETING_TXT,
             websocket=websocket,
-            tts_event = tts_event,
-            characater_name = character.name,
+            tts_event=tts_event,
+            characater_name=character.name,
             first_sentence=True,
         ))
 


### PR DESCRIPTION
Hello, this is my first PR. I've taken the liberty of running autopep8 --in-place --recursive . to format the Python files, assuming this is the preferred style. As I foresee many contributors in the future, might it be worth integrating a .precommit hook to ensure consistent formatting across all submissions? Thank you for your consideration!