### PR TITLE
[cleanup] remove unused self.model member

### DIFF
--- a/realtime_ai_character/audio/speech_to_text/whisper.py
+++ b/realtime_ai_character/audio/speech_to_text/whisper.py
@@ -25,6 +25,7 @@ class Whisper(Singleton, SpeechToText):
         super().__init__()
         if use == 'local':
             logger.info(f"Loading [Local Whisper] model: [{config.model}]...")
+            whisper.load_model(config.model)            
         self.recognizer = sr.Recognizer()
         self.use = use
         if DEBUG:

--- a/realtime_ai_character/audio/speech_to_text/whisper.py
+++ b/realtime_ai_character/audio/speech_to_text/whisper.py
@@ -25,7 +25,7 @@ class Whisper(Singleton, SpeechToText):
         super().__init__()
         if use == 'local':
             logger.info(f"Loading [Local Whisper] model: [{config.model}]...")
-            whisper.load_model(config.model)            
+            whisper.load_model(config.model)
         self.recognizer = sr.Recognizer()
         self.use = use
         if DEBUG:

--- a/realtime_ai_character/audio/speech_to_text/whisper.py
+++ b/realtime_ai_character/audio/speech_to_text/whisper.py
@@ -25,7 +25,6 @@ class Whisper(Singleton, SpeechToText):
         super().__init__()
         if use == 'local':
             logger.info(f"Loading [Local Whisper] model: [{config.model}]...")
-            self.model = whisper.load_model(config.model)
         self.recognizer = sr.Recognizer()
         self.use = use
         if DEBUG:


### PR DESCRIPTION
Hello~

`self.recognizer.recognize_whisper` appears to load the model, and self.model is not referenced elsewhere.
I'm not sure if it is intended to preload the model when the Whisper class is initialized instead of loading the model when Whisper.transcribe is first called, which could potentially impact the user experience.