### PR TITLE
fix websocket greeting not having '[end]' token

### DIFF
--- a/realtime_ai_character/websocket_routes.py
+++ b/realtime_ai_character/websocket_routes.py
@@ -124,6 +124,8 @@ async def handle_receive(
             characater_name=character.name,
             first_sentence=True,
         ))
+        # Send end of the greeting so the client knows when to start listening
+        await manager.send_message(message='[end]\n', websocket=websocket)
 
         async def on_new_token(token):
             return await manager.send_message(message=token, websocket=websocket)


### PR DESCRIPTION
Right now client cannot tell when the greeting finishes. Adding '[end]\n' after the greeting.