### PR TITLE
ios: Fix initial not loading when no log in

### DIFF
--- a/client/mobile/ios/rac/rac/Welcome/Settings/UserSettings.swift
+++ b/client/mobile/ios/rac/rac/Welcome/Settings/UserSettings.swift
@@ -39,6 +39,8 @@ class UserSettings: ObservableObject {
                 self.isLoggedIn = true
                 completion?(true)
             }
+        } else {
+            completion?(false)
         }
     }
 


### PR DESCRIPTION
If user is logged in, restarting the app will not call completion handler with `isUserLoggedIn = false`, then it will not connect to websocket. Fixing it by adding the missing callback.