### PR TITLE
[React Web] web crash if running out of eleven element credit

### DIFF
--- a/client/web/src/utils/audioUtils.js
+++ b/client/web/src/utils/audioUtils.js
@@ -28,11 +28,16 @@ const playAudio = (audioContextRef, audioPlayer, url) => {
     return new Promise((resolve) => {
       audioPlayer.current.src = url;
       audioPlayer.current.muted = true;  // Start muted
-      audioPlayer.current.play();
       audioPlayer.current.onended = resolve;
       audioPlayer.current.play().then(() => {
         audioPlayer.current.muted = false;  // Unmute after playback starts
-      }).catch(error => alert(`Playback failed because: ${error}`));
+      }).catch(error => {
+        if (error.name === 'NotSupportedError') {
+          alert(`Playback failed because: ${error}. Please check https://elevenlabs.io/subscription if you have encough characters left.`);
+        } else {
+          alert(`Playback failed because: ${error}`);
+        }
+      });
     });
 }
 


### PR DESCRIPTION
1. There is a bug in the current code that the audio will be called twice. If there is an error, it will crash the web and prevent me talk with agent even I am fine not hearing the voice. Screenshot:
<img width="438" alt="Screenshot 2023-07-23 at 22 22 05" src="https://github.com/Shaunwei/RealChar/assets/5102398/a8f7a39a-d714-40bb-8328-ad6439e6edbd">
<img width="1639" alt="Screenshot 2023-07-23 at 22 22 58" src="https://github.com/Shaunwei/RealChar/assets/5102398/d7c453d4-21db-4b4c-98c3-42bbf39be28d">

2. Give instruction to check elevenlabs site if this kind of error happenes.