### PR TITLE
Add Python version check

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8,9 +8,7 @@ import sys
 
 @click.group()
 def cli():
-    python_version = ".".join(map(str, sys.version_info[:2]))
-    click.echo(f"Python version: {python_version}")
-    assert float(python_version) <= "3.9", "Python 3.9+ is required."
+    assert sys.version_info > (3, 10), "Python version must be newer than 3.10"    
     pass
 
 

--- a/cli.py
+++ b/cli.py
@@ -3,10 +3,14 @@
 import click
 import os
 import subprocess
+import sys
 
 
 @click.group()
 def cli():
+    python_version = ".".join(map(str, sys.version_info[:2]))
+    click.echo(f"Python version: {python_version}")
+    assert float(python_version) <= "3.9", "Python 3.9+ is required."
     pass
 
 


### PR DESCRIPTION
### Change

Reflect the common issue that the user uses the wrong Python version #181. Add Python version check at `cli()`.

### Test

Local test with Python-3.5:
```
    assert float(python_version) <= 3.9, "Python 3.9+ is required."
AssertionError: Python 3.9+ is required.
```