### PR TITLE
ios: Fix sharing link to drop www

### DIFF
--- a/client/mobile/ios/rac/rac/Network/WebSocketClient.swift
+++ b/client/mobile/ios/rac/rac/Network/WebSocketClient.swift
@@ -13,7 +13,7 @@ import SwiftUI
 //let serverUrl: URL = URL(string: "http://127.0.0.1:8000/")!
 let serverUrl: URL = URL(string: "https://api.realchar.ai/")!
 //let webUrl: URL = URL(string: "http://127.0.0.1:3000/")!
-let webUrl: URL = URL(string: "https://www.realchar.ai/")!
+let webUrl: URL = URL(string: "https://realchar.ai/")!
 
 enum WebSocketError: Error {
     case disconnected


### PR DESCRIPTION
Looks like https://www.realchar.ai/ is not working well on iOS and we should just use https://realchar.ai/