### PR TITLE
ios: allow cancellation of current speech recognized

### DIFF
--- a/client/mobile/ios/rac/rac/Interactive/InteractiveView.swift
+++ b/client/mobile/ios/rac/rac/Interactive/InteractiveView.swift
@@ -59,7 +59,11 @@ struct InteractiveView: View {
                                  speechRecognizer: SpeechRecognizer(locale: preferenceSettings.languageOption.locale),
                                  onUpdateUserMessage: { message in
                     if messages.last?.role == .user {
-                        messages[messages.count - 1].content = message
+                        if !message.isEmpty {
+                            messages[messages.count - 1].content = message
+                        } else {
+                            messages.remove(at: messages.count - 1)
+                        }
                     } else {
                         if openMic {
                             voiceState = .listeningToUser

--- a/client/mobile/ios/rac/rac/Interactive/Text/ChatMessagesView.swift
+++ b/client/mobile/ios/rac/rac/Interactive/Text/ChatMessagesView.swift
@@ -117,17 +117,33 @@ struct CharacterMessage: View {
 
 struct UserMessage: View {
     let message: String
+    var onCancel: (() -> Void)? = nil
 
     var body: some View {
-        Text(message)
-            .font(Font.custom("Prompt", size: 20))
-            .multilineTextAlignment(.trailing)
-            .foregroundColor(.white)
-            .padding(.horizontal, 20)
-            .padding(.vertical, 11)
-            .background(Color(red: 0.4, green: 0.52, blue: 0.83).opacity(0.25))
-            .roundedCorner(20, corners: [.bottomLeft, .topLeft, .topRight])
-            .frame(maxWidth: .infinity, alignment: .topTrailing)
+        HStack(spacing: 8) {
+            Text(message)
+                .font(Font.custom("Prompt", size: 20))
+                .multilineTextAlignment(.trailing)
+                .foregroundColor(.white)
+                .padding(.vertical, 11)
+                .padding(.leading, 20)
+                .if(onCancel == nil) { view in
+                    view.padding(.trailing, 20)
+                }
+
+            if let onCancel {
+                Button {
+                    onCancel()
+                } label: {
+                    Image(systemName: "xmark.circle")
+                        .padding(12)
+                }
+                .buttonStyle(CustomButtonStyle())
+            }
+        }
+        .background(Color(red: 0.4, green: 0.52, blue: 0.83).opacity(0.25))
+        .roundedCorner(20, corners: [.bottomLeft, .topLeft, .topRight])
+        .frame(maxWidth: .infinity, alignment: .topTrailing)
     }
 }
 

--- a/client/mobile/ios/rac/rac/Interactive/Voice/VoiceMessageView.swift
+++ b/client/mobile/ios/rac/rac/Interactive/Voice/VoiceMessageView.swift
@@ -123,7 +123,13 @@ struct VoiceMessageView: View {
                         }
 
                         if messages.last?.role == .user, let lastUserMessage = messages.last {
-                            UserMessage(message: lastUserMessage.content)
+                            UserMessage(message: lastUserMessage.content,
+                                        onCancel: {
+                                onUpdateUserMessage("")
+                                speechRecognizer.transcript = ""
+                                speechRecognizer.stopTranscribing()
+                                speechRecognizer.startTranscribing()
+                            })
                                 .listRowSeparator(.hidden)
                                 .listRowBackground(Constants.realBlack)
                                 .id(0)


### PR DESCRIPTION
When the speech recognition result is not great, allow the user to cancel it and restart

![Simulator Screenshot - iPhone 14 Pro - 2023-08-08 at 22 15 49](https://github.com/Shaunwei/RealChar/assets/1465499/603c121e-f30e-4e04-958a-8416f61ae053)
