### PR TITLE
feat: support self-hosted embedding service via BentoML

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,11 @@ SERPAPI_API_KEY=
 # instructions: https://stackoverflow.com/a/62037708
 GOOGLE_API_KEY=
 GOOGLE_CSE_ID=
+
+# Enable SentenceEmbedding model served via BentoML
+# For local embedding service, use:
+#   docker run --rm -p 3000:3000 ghcr.io/bentoml/sentence-embedding-bento:0.1.0
+# Then set the following env var:
+#   BENTOML_EMBEDDING_ENDPOINT=http://localhost:3000
+# Instructions for customizing your embedding model server: https://github.com/bentoml/sentence-embedding-bento
+BENTOML_EMBEDDING_ENDPOINT=

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ __Demo settings: Web, GPT4, ElevenLabs with voice clone, Chroma, Google Speech t
 
 - ✅**Web**: [React JS](https://react.dev/), [Vanilla JS](http://vanilla-js.com/), [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)
 - ✅**Mobile**: [Swift](https://developer.apple.com/swift/), [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)
-- ✅**Backend**: [FastAPI](https://fastapi.tiangolo.com/), [SQLite](https://www.sqlite.org/index.html), [Docker](https://www.docker.com/)
+- ✅**Backend**: [FastAPI](https://fastapi.tiangolo.com/), [SQLite](https://www.sqlite.org/index.html), [Docker](https://www.docker.com/), [BentoML](https://bentoml.com/)
 - ✅**Data Ingestion**: [LlamaIndex](https://www.llamaindex.ai/), [Chroma](https://www.trychroma.com/)
 - ✅**LLM Orchestration**: [LangChain](https://langchain.com/), [Chroma](https://www.trychroma.com/)
 - ✅**LLM**: [OpenAI GPT3.5/4](https://platform.openai.com/docs/api-reference/chat), [Anthropic Claude 2](https://docs.anthropic.com/claude/docs/getting-started-with-claude)
@@ -155,6 +155,26 @@ Visit [ElevenLabs](https://beta.elevenlabs.io/) to create an account. You'll nee
 ```
 ELEVEN_LABS_API_KEY=<api key>
 ```
+</details>
+
+### 4. (Optional) Prepare self-hosted embedding service - BentoML Deployment Endpoint
+<details><summary>👇click me</summary>
+
+1. Install [Docker](https://docs.docker.com/engine/install/)
+
+2. Run the text embedding service docker image generated with BentoML:
+
+  ```bash
+  docker run --rm -p 3000:3000 ghcr.io/bentoml/sentence-embedding-bento:0.1.0
+  ```
+
+3. Set the Text Embedding Endpoint in your .env file:
+
+  ```
+  BENTOML_EMBEDDING_ENDPOINT=http://localhost:3000
+  ```
+
+For cloud deployment options and customizing your own embeddding model, check out the source repo [here](https://github.com/bentoml/sentence-embedding-bento)
 </details>
 
 ## 💿 Installation via Python

--- a/cli.py
+++ b/cli.py
@@ -69,10 +69,17 @@ def image_exists(name):
     return result.returncode == 0
 
 
+@click.command(help="Run BentoML text embedding service locally via Docker at localhost:3000")
+def run_embedding_service():
+    click.secho("Launching BentoML SentenceEmbedding Service...", fg='green')
+    subprocess.run(["docker", "run", "--rm", "-p", "3000:3000", "ghcr.io/bentoml/sentence-embedding-bento:0.1.0"])
+
+
 cli.add_command(docker_build)
 cli.add_command(docker_run)
 cli.add_command(docker_delete)
 cli.add_command(run_uvicorn)
+cli.add_command(run_embedding_service)
 
 
 if __name__ == '__main__':

--- a/realtime_ai_character/database/chroma.py
+++ b/realtime_ai_character/database/chroma.py
@@ -7,10 +7,23 @@ from realtime_ai_character.logger import get_logger
 load_dotenv()
 logger = get_logger(__name__)
 
-embedding = OpenAIEmbeddings(openai_api_key=os.getenv("OPENAI_API_KEY"))
-if os.getenv('OPENAI_API_TYPE') == 'azure':
-    embedding = OpenAIEmbeddings(openai_api_key=os.getenv("OPENAI_API_KEY"), deployment=os.getenv(
-        "OPENAI_API_EMBEDDING_DEPLOYMENT_NAME", "text-embedding-ada-002"), chunk_size=1)
+
+embedding_endpoint = os.getenv("BENTOML_EMBEDDING_ENDPOINT")
+
+if embedding_endpoint:
+    # Use self-hosted embedding model via BentoML API endpoint
+    from bentoml.client import Client
+    client = Client.from_url(embedding_endpoint)
+    embedding = client.encode
+else:
+    embedding = OpenAIEmbeddings(openai_api_key=os.getenv("OPENAI_API_KEY"))
+    if os.getenv('OPENAI_API_TYPE') == 'azure':
+        embedding = OpenAIEmbeddings(
+            openai_api_key=os.getenv("OPENAI_API_KEY"),
+            deployment=os.getenv(
+                "OPENAI_API_EMBEDDING_DEPLOYMENT_NAME", "text-embedding-ada-002"
+            ),
+            chunk_size=1)
 
 
 def get_chroma():

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aioconsole
 aiofiles
 alembic
 anthropic
+bentoml>=1.1
 chromadb>=0.4.2
 click
 EbookLib

--- a/sample_cloud_deployment/deployment.yaml
+++ b/sample_cloud_deployment/deployment.yaml
@@ -50,6 +50,8 @@ spec:
           value: <YOUR_AI_VOICE_ID>
         - name: BRUCE_VOICE
           value: <YOUR_AI_VOICE_ID>
+        - name: BENTOML_EMBEDDING_ENDPOINT
+          value: bentoml-embedding-service.<YOUR_DEPLOYMENT_NAMESPACE>.svc.cluster.local
 ---
 apiVersion: v1
 kind: Service

--- a/sample_cloud_deployment/embedding_service.yaml
+++ b/sample_cloud_deployment/embedding_service.yaml
@@ -1,0 +1,41 @@
+# For advanced BentoML deployment on kubernetes, see:
+#   https://www.kubeflow.org/docs/external-add-ons/serving/bentoml/
+#   https://github.com/bentoml/yatai
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bentoml-embedding-deployment
+  labels:
+    app: bentoml-text-embedding
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bentoml-text-embedding
+  template:
+    metadata:
+      labels:
+        app: bentoml-text-embedding
+    spec:
+      containers:
+      - name: bentoml-text-embedding
+        image: ghcr.io/bentoml/sentence-embedding-bento:0.1.0 
+        ports:
+        - containerPort: 3000
+        env:
+        - name: BENTOML_CONFIG_OPTIONS
+          value: "api_server.metrics.namespace=realchar,api_server.traffic.timeout=10"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bentoml-embedding-service
+spec:
+  type: ClusterIP
+  selector:
+    app: bentoml-text-embedding
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000
+


### PR DESCRIPTION
This PR adds an option for RealChar to use a self-hosted embedding service powered by SentenceBert and BentoML.

By default, this integration uses the docker image published [here](https://github.com/bentoml/sentence-embedding-bento/pkgs/container/sentence-embedding-bento)

The default model that comes with the docker image is all-MiniLM-L6-v2. RealChar users may customize it to use a different text embedding model based on their needs. Check out the source code for the embedding service here: https://github.com/bentoml/sentence-embedding-bento, 


TODO:
- [ ] Test the integration end-to-end
