### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate Models - using litellm

### DIFF
--- a/realtime_ai_character/llm/openai_llm.py
+++ b/realtime_ai_character/llm/openai_llm.py
@@ -5,7 +5,7 @@ from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 if os.getenv('OPENAI_API_TYPE') == 'azure':
     from langchain.chat_models import AzureChatOpenAI
 else:
-    from langchain.chat_models import ChatOpenAI
+    from langchain.chat_models import ChatLiteLLM
 from langchain.schema import BaseMessage, HumanMessage
 
 from realtime_ai_character.database.chroma import get_chroma
@@ -28,7 +28,7 @@ class OpenaiLlm(LLM):
                 streaming=True
             )
         else:
-            self.chat_open_ai = ChatOpenAI(
+            self.chat_open_ai = ChatLiteLLM(
                 model=model,
                 temperature=0.5,
                 streaming=True


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the OpenAI I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```

