### PR TITLE
Add local Llama2 support from llama2-wrapper backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ ANTHROPIC_API_KEY=YOUR_API_KEY
 # Anyscale Endpoint API Key
 ANYSCALE_ENDPOINT_API_KEY=
 # Local LLM with Openai Compatiable API
-# LOCAL_LLM_URL="http://localhost:8001/v1"
+# Example value: "http://localhost:8001/v1"
 LOCAL_LLM_URL=
 
 # Speech to text

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ OPENAI_API_KEY=YOUR_API_KEY
 ANTHROPIC_API_KEY=YOUR_API_KEY
 # Anyscale Endpoint API Key
 ANYSCALE_ENDPOINT_API_KEY=
+# Local LLM with Openai Compatiable API
+# LOCAL_LLM_URL="http://localhost:8001/v1"
+LOCAL_LLM_URL=
 
 # Speech to text
 # "LOCAL_WHISPER" or "OPENAI_WHISPER"(optional) or "GOOGLE"(optional)

--- a/realtime_ai_character/llm/__init__.py
+++ b/realtime_ai_character/llm/__init__.py
@@ -7,26 +7,29 @@ from realtime_ai_character.llm.base import LLM
 
 
 def get_llm(model="gpt-3.5-turbo-16k") -> LLM:
-    # temporaryly comment out all other llms
-    # need figure out how to set up llama2wrapper in frontend
-    from realtime_ai_character.llm.llama2wrapper_llm import Llama2wrapperLlm
-
-    return Llama2wrapperLlm(url=model)
-    # if model.startswith('gpt'):
-    #     from realtime_ai_character.llm.openai_llm import OpenaiLlm
-    #     return OpenaiLlm(model=model)
-    # elif model.startswith('claude'):
-    #     from realtime_ai_character.llm.anthropic_llm import AnthropicLlm
-    #     return AnthropicLlm(model=model)
-    # elif model.startswith('llama2-wrapper'):
-    #     from realtime_ai_character.llm.llama2wrapper_llm import Llama2wrapperLlm
-    #     return Llama2wrapperLlm(model=model.split(":")[1])
-    # elif "llama" in model:
-    #     # Currently use Anyscale to support llama models
-    #     from realtime_ai_character.llm.anyscale_llm import AnysacleLlm
-    #     return AnysacleLlm(model=model)
-    # else:
-    #     raise ValueError(f'Invalid llm model: {model}')
+    # temporaryly get url from .env LOCAL_LLM_URL
+    # need figure out how to set up model=url in frontend
+    # if select "Llama-2-70b" button from frontend,
+    # model here will be "meta-llama/Llama-2-70b-chat-hf"
+    model = os.getenv('LOCAL_LLM_URL')
+    print(model)
+    # return Llama2wrapperLlm(url=model)
+    if model.startswith('gpt'):
+        from realtime_ai_character.llm.openai_llm import OpenaiLlm
+        return OpenaiLlm(model=model)
+    elif model.startswith('claude'):
+        from realtime_ai_character.llm.anthropic_llm import AnthropicLlm
+        return AnthropicLlm(model=model)
+    elif "localhost" in model:
+        # Currently use llama2-wrapper to test local llama models
+        from realtime_ai_character.llm.local_llm import LocalLlm
+        return LocalLlm(url=model)
+    elif "llama" in model:
+        # Currently use Anyscale to support llama models
+        from realtime_ai_character.llm.anyscale_llm import AnysacleLlm
+        return AnysacleLlm(model=model)
+    else:
+        raise ValueError(f'Invalid llm model: {model}')
 
 
 @cache
@@ -38,6 +41,6 @@ def get_chatmodel_from_env() -> BaseChatModel:
         return get_llm(model='claude-2').chat_anthropic
     elif os.getenv('ANYSCALE_API_KEY'):
         return get_llm(model='meta-llama/Llama-2-70b-chat-hf').chat_open_ai
-    elif os.getenv('LLAMA2WRAPPER_URL'):
-        return get_llm(model=os.getenv('LLAMA2WRAPPER_URL')).chat_open_ai
+    elif os.getenv('LOCAL_LLM_URL'):
+        return get_llm(model=os.getenv('LOCAL_LLM_URL')).chat_open_ai
     raise ValueError('No llm api key found in env')

--- a/realtime_ai_character/llm/__init__.py
+++ b/realtime_ai_character/llm/__init__.py
@@ -6,19 +6,28 @@ from langchain.chat_models.base import BaseChatModel
 from realtime_ai_character.llm.base import LLM
 
 
-def get_llm(model='gpt-3.5-turbo-16k') -> LLM:
-    if model.startswith('gpt'):
-        from realtime_ai_character.llm.openai_llm import OpenaiLlm
-        return OpenaiLlm(model=model)
-    elif model.startswith('claude'):
-        from realtime_ai_character.llm.anthropic_llm import AnthropicLlm
-        return AnthropicLlm(model=model)
-    elif "llama" in model:
-        # Currently use Anyscale to support llama models
-        from realtime_ai_character.llm.anyscale_llm import AnysacleLlm
-        return AnysacleLlm(model=model)
-    else:
-        raise ValueError(f'Invalid llm model: {model}')
+def get_llm(model="gpt-3.5-turbo-16k") -> LLM:
+    # temporaryly comment out all other llms
+    # need figure out how to set up llama2wrapper in frontend
+    from realtime_ai_character.llm.llama2wrapper_llm import Llama2wrapperLlm
+
+    return Llama2wrapperLlm(url=model)
+    # if model.startswith('gpt'):
+    #     from realtime_ai_character.llm.openai_llm import OpenaiLlm
+    #     return OpenaiLlm(model=model)
+    # elif model.startswith('claude'):
+    #     from realtime_ai_character.llm.anthropic_llm import AnthropicLlm
+    #     return AnthropicLlm(model=model)
+    # elif model.startswith('llama2-wrapper'):
+    #     from realtime_ai_character.llm.llama2wrapper_llm import Llama2wrapperLlm
+    #     return Llama2wrapperLlm(model=model.split(":")[1])
+    # elif "llama" in model:
+    #     # Currently use Anyscale to support llama models
+    #     from realtime_ai_character.llm.anyscale_llm import AnysacleLlm
+    #     return AnysacleLlm(model=model)
+    # else:
+    #     raise ValueError(f'Invalid llm model: {model}')
+
 
 @cache
 def get_chatmodel_from_env() -> BaseChatModel:
@@ -29,4 +38,6 @@ def get_chatmodel_from_env() -> BaseChatModel:
         return get_llm(model='claude-2').chat_anthropic
     elif os.getenv('ANYSCALE_API_KEY'):
         return get_llm(model='meta-llama/Llama-2-70b-chat-hf').chat_open_ai
+    elif os.getenv('LLAMA2WRAPPER_URL'):
+        return get_llm(model=os.getenv('LLAMA2WRAPPER_URL')).chat_open_ai
     raise ValueError('No llm api key found in env')

--- a/realtime_ai_character/llm/__init__.py
+++ b/realtime_ai_character/llm/__init__.py
@@ -7,12 +7,6 @@ from realtime_ai_character.llm.base import LLM
 
 
 def get_llm(model="gpt-3.5-turbo-16k") -> LLM:
-    # temporaryly get url from .env LOCAL_LLM_URL
-    # need figure out how to set up model=url in frontend
-    # if select "Llama-2-70b" button from frontend,
-    # model here will be "meta-llama/Llama-2-70b-chat-hf"
-    model = os.getenv('LOCAL_LLM_URL')
-    print(model)
     # return Llama2wrapperLlm(url=model)
     if model.startswith('gpt'):
         from realtime_ai_character.llm.openai_llm import OpenaiLlm
@@ -21,9 +15,13 @@ def get_llm(model="gpt-3.5-turbo-16k") -> LLM:
         from realtime_ai_character.llm.anthropic_llm import AnthropicLlm
         return AnthropicLlm(model=model)
     elif "localhost" in model:
-        # Currently use llama2-wrapper to test local llama models
-        from realtime_ai_character.llm.local_llm import LocalLlm
-        return LocalLlm(url=model)
+        # Currently use llama2-wrapper to run local llama models
+        local_llm_url = os.getenv('LOCAL_LLM_URL', '')
+        if local_llm_url:
+            from realtime_ai_character.llm.local_llm import LocalLlm
+            return LocalLlm(url=local_llm_url)
+        else:
+            raise ValueError('LOCAL_LLM_URL not set')
     elif "llama" in model:
         # Currently use Anyscale to support llama models
         from realtime_ai_character.llm.anyscale_llm import AnysacleLlm

--- a/realtime_ai_character/llm/__init__.py
+++ b/realtime_ai_character/llm/__init__.py
@@ -7,7 +7,6 @@ from realtime_ai_character.llm.base import LLM
 
 
 def get_llm(model="gpt-3.5-turbo-16k") -> LLM:
-    # return Llama2wrapperLlm(url=model)
     if model.startswith('gpt'):
         from realtime_ai_character.llm.openai_llm import OpenaiLlm
         return OpenaiLlm(model=model)

--- a/realtime_ai_character/llm/llama2wrapper_llm.py
+++ b/realtime_ai_character/llm/llama2wrapper_llm.py
@@ -1,0 +1,82 @@
+import os
+from typing import List, Union
+
+from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain.chat_models import ChatOpenAI
+from langchain.schema import BaseMessage, HumanMessage
+
+from realtime_ai_character.database.chroma import get_chroma
+from realtime_ai_character.llm.base import (
+    AsyncCallbackAudioHandler,
+    AsyncCallbackTextHandler,
+    LLM,
+    SearchAgent,
+)
+from realtime_ai_character.logger import get_logger
+from realtime_ai_character.utils import Character
+
+
+logger = get_logger(__name__)
+
+
+class Llama2wrapperLlm(LLM):
+    def __init__(self, url):
+        self.chat_open_ai = ChatOpenAI(
+            model="llama2-wrapper",
+            temperature=0.5,
+            streaming=True,
+            # openai_api_base=url,
+            # temporaryly use fixed url
+            openai_api_base="http://localhost:8001/v1",
+            
+        )
+        self.config = {"model": "llama2-wrapper", "temperature": 0.5, "streaming": True}
+        self.db = get_chroma()
+        self.search_agent = None
+        self.search_agent = SearchAgent()
+
+    def get_config(self):
+        return self.config
+
+    async def achat(
+        self,
+        history: Union[List[BaseMessage], List[str]],
+        user_input: str,
+        user_input_template: str,
+        callback: AsyncCallbackTextHandler,
+        audioCallback: AsyncCallbackAudioHandler,
+        character: Character,
+        useSearch: bool = False,
+        metadata: dict = None,
+        *args,
+        **kwargs,
+    ) -> str:
+        # 1. Generate context
+        context = self._generate_context(user_input, character)
+        # Get search result if enabled
+        if useSearch:
+            context += self.search_agent.search(user_input)
+        
+        # 2. Add user input to history
+        history.append(
+            HumanMessage(
+                content=user_input_template.format(context=context, query=user_input)
+            )
+        )
+
+        # 3. Generate response
+        response = await self.chat_open_ai.agenerate(
+            [history],
+            callbacks=[callback, audioCallback, StreamingStdOutCallbackHandler()],
+            metadata=metadata,
+        )
+        logger.info(f"Response: {response}")
+        return response.generations[0][0].text
+
+    def _generate_context(self, query, character: Character) -> str:
+        docs = self.db.similarity_search(query)
+        docs = [d for d in docs if d.metadata["character_name"] == character.name]
+        logger.info(f"Found {len(docs)} documents")
+
+        context = "\n".join([d.page_content for d in docs])
+        return context

--- a/realtime_ai_character/llm/local_llm.py
+++ b/realtime_ai_character/llm/local_llm.py
@@ -26,7 +26,6 @@ class LocalLlm(LLM):
             temperature=0.5,
             streaming=True,
             openai_api_base=url,
-            # openai_api_base="http://localhost:8001/v1",
             
         )
         self.config = {"model": "Local LLM", "temperature": 0.5, "streaming": True}

--- a/realtime_ai_character/llm/local_llm.py
+++ b/realtime_ai_character/llm/local_llm.py
@@ -26,7 +26,6 @@ class LocalLlm(LLM):
             temperature=0.5,
             streaming=True,
             openai_api_base=url,
-            # temporaryly use fixed url
             # openai_api_base="http://localhost:8001/v1",
             
         )

--- a/realtime_ai_character/llm/local_llm.py
+++ b/realtime_ai_character/llm/local_llm.py
@@ -19,18 +19,18 @@ from realtime_ai_character.utils import Character
 logger = get_logger(__name__)
 
 
-class Llama2wrapperLlm(LLM):
+class LocalLlm(LLM):
     def __init__(self, url):
         self.chat_open_ai = ChatOpenAI(
-            model="llama2-wrapper",
+            model="Local LLM",
             temperature=0.5,
             streaming=True,
-            # openai_api_base=url,
+            openai_api_base=url,
             # temporaryly use fixed url
-            openai_api_base="http://localhost:8001/v1",
+            # openai_api_base="http://localhost:8001/v1",
             
         )
-        self.config = {"model": "llama2-wrapper", "temperature": 0.5, "streaming": True}
+        self.config = {"model": "Local LLM", "temperature": 0.5, "streaming": True}
         self.db = get_chroma()
         self.search_agent = None
         self.search_agent = SearchAgent()


### PR DESCRIPTION
Hi @Shaunwei @pycui ,
I am working on the project [llama2-wrapper](https://github.com/liltom-eth/llama2-webui) to make it easily call Llama2 model locally as an LLM backend.
And to follow up on the Twitter [discussion](https://twitter.com/agishaun/status/1691210486401183746?s=20), I made this PR as a showcase running Realchar and Llama2 locally on an M2 Macbook Air.
Here is the demo:
![realchar](https://github.com/Shaunwei/RealChar/assets/11456256/90fb092c-036e-4f44-b3a5-9a1e67d66595)


## How to run on Mac:
### Run OpenAI Compatible API on Llama2 models
```
pip install llama2-wrapper
python -m llama2_wrapper.server  --port 8001
# Llama2 running on http://localhost:8001
```
### Start Realchar
```
python cli.py web-build
python cli.py run-uvicorn
```
## Implementation
I found it hard to load local LLM object directly as backend since Realchar is using `langchain.chat_models` as the LLM.
Thus I chose to run a local LLM as OpenAI Compatible API, then call `langchain.chat_models.ChatOpenAI` to run LLM from the local URL.

## Issues
Now the PR still has issues automatically passing customize URL from `.env` as the model URL to llm. I haven't figured out how to add a new LLM option in the new Realchar Web UI and hard code to make Realchar run on llama2-wrapper.


## Showcase
This showcase is running Realchar and Llama2 on Mac. (13.70 tokens/sec through llama.cpp)
Another interesting showcase might be running Realchar and Llama2 on free colab T4 GPU. (18.19 tokens/sec through gptq)
